### PR TITLE
update readme usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,10 +236,10 @@ Here are some example codes:
 .. code-block:: python
 
     from flask import Flask, request, jsonify
-    import flask_excel
+    import flask_excel as excel
 
     app=Flask(__name__)
-    flask_excel.init_excel(app)
+    excel.init_excel(app)
 
     @app.route("/upload", methods=['GET', 'POST'])
     def upload_file():


### PR DESCRIPTION
NameError 'excel' is not defined fixed in '/export' route