### PR TITLE
fixed missing ',' separating method parameters in docs

### DIFF
--- a/.moban.d/docs/source/index.rst.jj2
+++ b/.moban.d/docs/source/index.rst.jj2
@@ -305,7 +305,7 @@ Response methods
    :param status: same as :meth:`~flask_excel.make_response`
    :param file_name: same as :meth:`~flask_excel.make_response`
 
-.. method:: make_response_from_a_table(session, table, file_type status=200, file_name=None)
+.. method:: make_response_from_a_table(session, table, file_type, status=200, file_name=None)
 
    Produce a single sheet Excel book of *file_type*
 
@@ -315,7 +315,7 @@ Response methods
    :param status: same as :meth:`~flask_excel.make_response`
    :param file_name: same as :meth:`~flask_excel.make_response`
 
-.. method:: make_response_from_query_sets(query_sets, column_names, file_type status=200, file_name=None)
+.. method:: make_response_from_query_sets(query_sets, column_names, file_type, status=200, file_name=None)
 
    Produce a single sheet Excel book of *file_type* from your custom database queries
 
@@ -325,7 +325,7 @@ Response methods
    :param status: same as :meth:`~flask_excel.make_response`
    :param file_name: same as :meth:`~flask_excel.make_response`
 
-.. method:: make_response_from_tables(session, tables, file_type status=200, file_name=None)
+.. method:: make_response_from_tables(session, tables, file_type, status=200, file_name=None)
 
    Produce a multiple sheet Excel book of *file_type*. It becomes the same
    as :meth:`~flask_excel.make_response_from_a_table` if you pass *tables*


### PR DESCRIPTION
Fixes missing ',' that separates parameters (file_type and status=200) in in docs:
1. make_response_from_a_table
2. make_response_from_query_sets
3. make_response_from_tables